### PR TITLE
Fix splash themes

### DIFF
--- a/src/lib/splash-screens.ts
+++ b/src/lib/splash-screens.ts
@@ -88,12 +88,12 @@ function buildSplashStartupImages(): { url: string; media: string }[] {
   for (const dims of Object.keys(SPLASH_BY_DIMS)) {
     const deviceMedia = SPLASH_BY_DIMS[dims];
     out.push({
-      url: `${SPLASH_DIR}/apple-splash-dark-${dims}.jpg`,
-      media: `(prefers-color-scheme: dark) and ${deviceMedia}`,
-    });
-    out.push({
       url: `${SPLASH_DIR}/apple-splash-${dims}.jpg`,
       media: deviceMedia,
+    });
+    out.push({
+      url: `${SPLASH_DIR}/apple-splash-dark-${dims}.jpg`,
+      media: `(prefers-color-scheme: dark) and ${deviceMedia}`,
     });
   }
   return out;


### PR DESCRIPTION
Revert "fix: list dark splash screen variants before light to enable dark mode matching"

This reverts commit 86d0054407fbc3e84020d8edc714aeb5dd80dddf.

The initial 'fix' seemed to actually break the splash screen theming