### PR TITLE
perf: optimize tournament dashboard rendering

### DIFF
--- a/.cursor/rules/project-writing-style.mdc
+++ b/.cursor/rules/project-writing-style.mdc
@@ -1,0 +1,11 @@
+---
+description: project writing style for generated text
+alwaysApply: true
+---
+
+# project writing style
+
+- use lowercase for generated prose unless capitalization is technically required.
+- this applies to code comments, documentation, pr titles, pr descriptions, commit bodies, issue text, and chat-proposed text intended for the project.
+- keep proper casing only for required identifiers, commands, paths, package names, acronyms, schema enum values, translation keys, and quoted text that must remain exact.
+- oxford english spelling required

--- a/.cursor/skills/mobile-dev/SKILL.md
+++ b/.cursor/skills/mobile-dev/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: mobile-dev
+description: configure mobile development environment
+disable-model-invocation: true
+---
+
+# mobile dev setup
+
+set up your mobile development environment to be accessible via local network.
+
+## what this does
+
+1. detects your local ip address (192.168.x.x)
+2. updates `src/lib/config/urls.ts` with your local ip
+3. updates `next.config.mjs` to allow dev connections from your local IP
+4. confirms the setup with the accessible URL
+
+## usage
+
+run the setup script: `scripts/setup-mobile-dev.sh`

--- a/.cursor/skills/mobile-dev/scripts/setup-mobile-dev.sh
+++ b/.cursor/skills/mobile-dev/scripts/setup-mobile-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# step 1: get local ip
+localIp=$(ifconfig | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | grep '^192\.168\.' | head -n 1)
+
+if [ -z "$localIp" ]; then
+  echo "error: no 192.168.x.x ip address found"
+  exit 1
+fi
+
+echo "detected local ip: $localIp"
+
+# step 2: update src/lib/config/urls.ts
+sed -i "" "s/localhost/$localIp/g" src/lib/config/urls.ts
+
+# step 3: update next.config.mjs
+if grep -q "allowedDevOrigins" next.config.mjs; then
+  sed -i "" "s/allowedDevOrigins: \[.*\]/allowedDevOrigins: [\"$localIp\"]/g" next.config.mjs
+else
+  sed -i "" "/nextConfig = {/a\\
+  allowedDevOrigins: [\"$localIp\"],
+" next.config.mjs
+fi
+
+# step 4: show confirmation
+echo "setup complete!"
+echo "http://$localIp:3000 is now accessible via local network"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,9 @@ bun db:push                  # generate + run migrations
 bun db:studio                # open drizzle studio
 bun generate-erd             # generate entity-relationship diagram
 bun generate-openapi         # generate openapi spec
+bash .cursor/skills/mobile-dev/scripts/setup-mobile-dev.sh
+                             # mobile dev setup: detect 192.168 ip,
+                             # update local urls, set nextConfig.allowedDevOrigins
 ```
 
 always run `bun check` before pushing. use single-file test when validating changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ allowed infra exceptions (non-domain): oauth callbacks/login routes, cron/migrat
 
 see `docs/architecture/type-contracts.md` for migration rules and enforcement checklist.
 
+## development flow
+
+- feature and project branches target `beta` for pull requests.
+- `main` accepts pull requests only from `beta`; do not open feature-branch prs directly into `main`.
+- if a user asks to create a feature-branch pr against `main`, confirm whether they meant `beta` before proceeding.
+
 ## architecture
 
 - next.js 16 app router with react 19, bun runtime

--- a/src/app/tournaments/[id]/dashboard/carousel-container.tsx
+++ b/src/app/tournaments/[id]/dashboard/carousel-container.tsx
@@ -1,4 +1,4 @@
-import { DashboardContextType } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import { DashboardTab } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import tabs from '@/app/tournaments/[id]/dashboard/tabs';
 import useScrollableContainer from '@/components/hooks/use-scrollable-container';
 import {
@@ -77,8 +77,8 @@ const CarouselIteratee: FC<{
 };
 
 type CarouselProps = {
-  currentTab: DashboardContextType['currentTab'];
-  setCurrentTab: Dispatch<SetStateAction<DashboardContextType['currentTab']>>;
+  currentTab: DashboardTab;
+  setCurrentTab: Dispatch<SetStateAction<DashboardTab>>;
   setScrolling: Dispatch<SetStateAction<boolean>>;
 };
 

--- a/src/app/tournaments/[id]/dashboard/dashboard-context.ts
+++ b/src/app/tournaments/[id]/dashboard/dashboard-context.ts
@@ -2,26 +2,46 @@ import { TournamentAuthStatus } from '@/server/zod/enums';
 import { DashboardMessage } from '@/types/tournament-ws-events';
 import { createContext, Dispatch, SetStateAction } from 'react';
 
+export type DashboardTab = 'main' | 'table' | 'games';
+
 export const DashboardContext = createContext<DashboardContextType>({
-  currentTab: 'main',
   sendJsonMessage: () => null,
   status: 'viewer',
   playerId: null,
   userId: undefined,
-  selectedGameId: null,
-  setSelectedGameId: () => null,
+});
+
+export const DashboardTabContext = createContext<DashboardTabContextType>({
+  currentTab: 'main',
+});
+
+export const DashboardRoundContext = createContext<DashboardRoundContextType>({
   roundInView: 1,
   setRoundInView: () => null,
 });
 
+export const SelectedGameContext = createContext<SelectedGameContextType>({
+  selectedGameId: null,
+  setSelectedGameId: () => null,
+});
+
 export type DashboardContextType = {
-  currentTab: 'main' | 'table' | 'games';
   sendJsonMessage: (_jsonMessage: DashboardMessage, _keep?: boolean) => void;
   status: TournamentAuthStatus;
   playerId: string | null;
   userId: string | undefined;
-  selectedGameId: string | null;
-  setSelectedGameId: Dispatch<SetStateAction<string | null>>;
+};
+
+export type DashboardTabContextType = {
+  currentTab: DashboardTab;
+};
+
+export type DashboardRoundContextType = {
   roundInView: number;
   setRoundInView: Dispatch<SetStateAction<number>>;
+};
+
+export type SelectedGameContextType = {
+  selectedGameId: string | null;
+  setSelectedGameId: Dispatch<SetStateAction<string | null>>;
 };

--- a/src/app/tournaments/[id]/dashboard/desktop/dashboard-desktop.tsx
+++ b/src/app/tournaments/[id]/dashboard/desktop/dashboard-desktop.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { TabProps } from '@/app/tournaments/[id]/dashboard';
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardContext,
+  DashboardRoundContext,
+  DashboardTabContext,
+  SelectedGameContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import Games from '@/app/tournaments/[id]/dashboard/tabs/games';
 import Main from '@/app/tournaments/[id]/dashboard/tabs/main';
 import TournamentTable from '@/app/tournaments/[id]/dashboard/tabs/table';
@@ -13,7 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { TournamentAuthStatus } from '@/server/zod/enums';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const DashboardDesktop: React.FC<DashboardDesktopProps> = ({
   currentTab,
@@ -32,9 +37,34 @@ const DashboardDesktop: React.FC<DashboardDesktopProps> = ({
     queryClient,
     setRoundInView,
   );
-  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+
+  const dashboardValue = useMemo(
+    () => ({
+      sendJsonMessage,
+      status,
+      playerId,
+      userId,
+    }),
+    [playerId, sendJsonMessage, status, userId],
+  );
+  const tabValue = useMemo(() => ({ currentTab }), [currentTab]);
+  const roundValue = useMemo(
+    () => ({
+      roundInView,
+      setRoundInView,
+    }),
+    [roundInView, setRoundInView],
+  );
+  const selectedGameValue = useMemo(
+    () => ({
+      selectedGameId,
+      setSelectedGameId,
+    }),
+    [selectedGameId, setSelectedGameId],
+  );
 
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -46,61 +76,55 @@ const DashboardDesktop: React.FC<DashboardDesktopProps> = ({
     };
   }, []);
 
-  const toggleFullscreen = async () => {
+  const toggleFullscreen = useCallback(async () => {
     if (!containerRef.current) return;
     if (document.fullscreenElement) {
       await document.exitFullscreen();
     } else {
       await containerRef.current.requestFullscreen();
     }
-  };
+  }, []);
 
   return (
-    <DashboardContext.Provider
-      value={{
-        currentTab,
-        sendJsonMessage,
-        status,
-        playerId,
-        userId,
-        setSelectedGameId,
-        selectedGameId,
-        roundInView,
-        setRoundInView,
-      }}
-    >
-      <Overlay open={!!selectedGameId} />
-      <div className="h-mk-content-height relative inset-0 flex flex-col overflow-hidden">
-        <Main toggleFullscreen={toggleFullscreen} />
-        <div
-          ref={containerRef}
-          className="p-mk px-mk-2 flex flex-1 gap-2 overflow-hidden lg:flex-row"
-        >
-          <Card className="bg-background relative size-full overflow-hidden">
-            <CardContent className="flex size-full flex-col overflow-y-auto p-0">
-              <TournamentTable />
-              <Fades from="from-background" to="to-background" />
-            </CardContent>
-          </Card>
-          <Card className="bg-background relative size-full overflow-hidden">
-            <CardContent className="flex size-full flex-col overflow-y-auto p-0">
-              <Games />
-              <Fades from="from-background" to="to-background" />
-            </CardContent>
-          </Card>
-          {isFullscreen && (
-            <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
-              <Button
-                className="opacity-30 duration-500 hover:opacity-90"
-                variant="secondary"
-                onClick={toggleFullscreen}
+    <DashboardContext.Provider value={dashboardValue}>
+      <DashboardTabContext.Provider value={tabValue}>
+        <DashboardRoundContext.Provider value={roundValue}>
+          <SelectedGameContext.Provider value={selectedGameValue}>
+            <Overlay open={!!selectedGameId} />
+            <div className="h-mk-content-height relative inset-0 flex flex-col overflow-hidden">
+              <Main toggleFullscreen={toggleFullscreen} />
+              <div
+                ref={containerRef}
+                className="p-mk px-mk-2 flex flex-1 gap-2 overflow-hidden lg:flex-row"
               >
-                <FormattedMessage id="Tournament.Main.minimize" />
-              </Button>
+                <Card className="bg-background relative size-full overflow-hidden">
+                  <CardContent className="flex size-full flex-col overflow-y-auto p-0">
+                    <TournamentTable />
+                    <Fades from="from-background" to="to-background" />
+                  </CardContent>
+                </Card>
+                <Card className="bg-background relative size-full overflow-hidden">
+                  <CardContent className="flex size-full flex-col overflow-y-auto p-0">
+                    <Games />
+                    <Fades from="from-background" to="to-background" />
+                  </CardContent>
+                </Card>
+                {isFullscreen && (
+                  <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+                    <Button
+                      className="opacity-30 duration-500 hover:opacity-90"
+                      variant="secondary"
+                      onClick={toggleFullscreen}
+                    >
+                      <FormattedMessage id="Tournament.Main.minimize" />
+                    </Button>
+                  </div>
+                )}
+              </div>
             </div>
-          )}
-        </div>
-      </div>
+          </SelectedGameContext.Provider>
+        </DashboardRoundContext.Provider>
+      </DashboardTabContext.Provider>
     </DashboardContext.Provider>
   );
 };

--- a/src/app/tournaments/[id]/dashboard/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DashboardContextType } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import { DashboardTab } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import DashboardDesktop from '@/app/tournaments/[id]/dashboard/desktop/dashboard-desktop';
 import DashboardMobile from '@/app/tournaments/[id]/dashboard/mobile/dashboard-mobile';
 import { MediaQueryContext } from '@/components/providers/media-query-context';
@@ -15,8 +15,7 @@ const Dashboard: FC<TournamentPageContentProps> = ({
   playerId,
   currentRound,
 }) => {
-  const [currentTab, setCurrentTab] =
-    useState<DashboardContextType['currentTab']>('main');
+  const [currentTab, setCurrentTab] = useState<DashboardTab>('main');
   const { isDesktop } = useContext(MediaQueryContext);
   const Component = isDesktop ? DashboardDesktop : DashboardMobile;
 
@@ -35,8 +34,8 @@ const Dashboard: FC<TournamentPageContentProps> = ({
 };
 
 export type TabProps = {
-  currentTab: DashboardContextType['currentTab'];
-  setCurrentTab: Dispatch<SetStateAction<DashboardContextType['currentTab']>>;
+  currentTab: DashboardTab;
+  setCurrentTab: Dispatch<SetStateAction<DashboardTab>>;
   top?: string;
 };
 

--- a/src/app/tournaments/[id]/dashboard/mobile/dashboard-mobile.tsx
+++ b/src/app/tournaments/[id]/dashboard/mobile/dashboard-mobile.tsx
@@ -3,7 +3,10 @@
 import CarouselContainer from '@/app/tournaments/[id]/dashboard/carousel-container';
 import {
   DashboardContext,
-  DashboardContextType,
+  DashboardRoundContext,
+  DashboardTabContext,
+  DashboardTab,
+  SelectedGameContext,
 } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import ShuffleButton from '@/app/tournaments/[id]/dashboard/shuffle-button';
 import TabsContainer from '@/app/tournaments/[id]/dashboard/tabs-container';
@@ -12,7 +15,7 @@ import { useDashboardWebsocket } from '@/components/hooks/use-dashboard-websocke
 import FabProvider from '@/components/ui-custom/fab-provider';
 import { TournamentAuthStatus } from '@/server/zod/enums';
 import { useQueryClient } from '@tanstack/react-query';
-import { Dispatch, ReactNode, SetStateAction, useState } from 'react';
+import { Dispatch, ReactNode, SetStateAction, useMemo, useState } from 'react';
 
 interface DashboardMobileProps {
   session: string | null;
@@ -21,11 +24,11 @@ interface DashboardMobileProps {
   playerId: string | null;
   userId: string | undefined;
   currentRound: number | null;
-  currentTab: DashboardContextType['currentTab'];
-  setCurrentTab: Dispatch<SetStateAction<DashboardContextType['currentTab']>>;
+  currentTab: DashboardTab;
+  setCurrentTab: Dispatch<SetStateAction<DashboardTab>>;
 }
 
-const fabTabMap: Record<DashboardContextType['currentTab'], ReactNode> = {
+const fabTabMap: Record<DashboardTab, ReactNode> = {
   main: <AddPlayerDrawer />,
   table: <AddPlayerDrawer />,
   games: <ShuffleButton />,
@@ -49,35 +52,57 @@ const DashboardMobile: React.FC<DashboardMobileProps> = ({
     queryClient,
     setRoundInView,
   );
-  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
   const fabContent = fabTabMap[currentTab];
   const [scrolling, setScrolling] = useState(false);
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+
+  const dashboardValue = useMemo(
+    () => ({
+      sendJsonMessage,
+      status,
+      playerId,
+      userId,
+    }),
+    [playerId, sendJsonMessage, status, userId],
+  );
+  const tabValue = useMemo(() => ({ currentTab }), [currentTab]);
+  const roundValue = useMemo(
+    () => ({
+      roundInView,
+      setRoundInView,
+    }),
+    [roundInView, setRoundInView],
+  );
+  const selectedGameValue = useMemo(
+    () => ({
+      selectedGameId,
+      setSelectedGameId,
+    }),
+    [selectedGameId, setSelectedGameId],
+  );
 
   return (
-    <DashboardContext.Provider
-      value={{
-        currentTab,
-        sendJsonMessage,
-        status,
-        playerId,
-        userId,
-        setSelectedGameId,
-        selectedGameId,
-        roundInView,
-        setRoundInView,
-      }}
-    >
-      <TabsContainer currentTab={currentTab} setCurrentTab={setCurrentTab} />
-      <CarouselContainer
-        currentTab={currentTab}
-        setCurrentTab={setCurrentTab}
-        setScrolling={setScrolling}
-      />
-      <FabProvider
-        status={status}
-        fabContent={fabContent}
-        scrolling={scrolling}
-      />
+    <DashboardContext.Provider value={dashboardValue}>
+      <DashboardTabContext.Provider value={tabValue}>
+        <DashboardRoundContext.Provider value={roundValue}>
+          <SelectedGameContext.Provider value={selectedGameValue}>
+            <TabsContainer
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+            />
+            <CarouselContainer
+              currentTab={currentTab}
+              setCurrentTab={setCurrentTab}
+              setScrolling={setScrolling}
+            />
+            <FabProvider
+              status={status}
+              fabContent={fabContent}
+              scrolling={scrolling}
+            />
+          </SelectedGameContext.Provider>
+        </DashboardRoundContext.Provider>
+      </DashboardTabContext.Provider>
     </DashboardContext.Provider>
   );
 };

--- a/src/app/tournaments/[id]/dashboard/tabs-container.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs-container.tsx
@@ -1,7 +1,7 @@
 import { TabProps } from '@/app/tournaments/[id]/dashboard';
 import {
-  DashboardContext,
-  DashboardContextType,
+  DashboardTab,
+  SelectedGameContext,
 } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import tabs from '@/app/tournaments/[id]/dashboard/tabs';
 import Overlay from '@/components/overlay';
@@ -10,18 +10,15 @@ import { useTranslations } from 'next-intl';
 import { FC, useContext, useRef } from 'react';
 
 const TabsContainer: FC<TabProps> = ({ currentTab, setCurrentTab }) => {
-  const value: DashboardContextType['currentTab'] = currentTab;
   const tabRef = useRef<HTMLDivElement>(null);
   const t = useTranslations('Tournament.Tabs');
-  const { selectedGameId } = useContext(DashboardContext);
+  const { selectedGameId } = useContext(SelectedGameContext);
 
   return (
     <Tabs
       defaultValue="main"
-      onValueChange={(value) =>
-        setCurrentTab(value as DashboardContextType['currentTab'])
-      }
-      value={value}
+      onValueChange={(value) => setCurrentTab(value as DashboardTab)}
+      value={currentTab}
       className={`relative h-10 w-full rounded-none`}
     >
       <Overlay open={!!selectedGameId} />

--- a/src/app/tournaments/[id]/dashboard/tabs/games/game/game-item.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/game/game-item.tsx
@@ -4,53 +4,48 @@ import Result, {
   ResultProps,
 } from '@/app/tournaments/[id]/dashboard/tabs/games/game/result';
 import useTournamentSetGameResult from '@/components/hooks/mutation-hooks/use-tournament-set-game-result';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentGameResultInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import useOutsideClick from '@/components/hooks/use-outside-click';
 import PortalWrapper from '@/components/portal-wrapper';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { GameResult } from '@/server/zod/enums';
-import { GameModel } from '@/server/zod/tournaments';
 import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-import { FC, useContext, useRef } from 'react';
+import { Dispatch, FC, memo, SetStateAction, useContext, useRef } from 'react';
 import { toast } from 'sonner';
 
 const GameItem: FC<GameProps> = ({
   id,
   result,
-  playerLeft,
-  playerRight,
+  whiteId,
+  whiteNickname,
+  blackId,
+  blackNickname,
   roundNumber,
+  selected,
+  setSelectedGameId,
 }) => {
   const { id: tournamentId } = useParams<{ id: string }>();
   const t = useTranslations('Toasts');
-  const {
-    selectedGameId,
-    setSelectedGameId,
-    sendJsonMessage,
-    status,
-    playerId,
-    userId,
-  } = useContext(DashboardContext);
+  const { sendJsonMessage, status, playerId, userId } =
+    useContext(DashboardContext);
   const queryClient = useQueryClient();
   const mutation = useTournamentSetGameResult(queryClient, {
     tournamentId,
     sendJsonMessage,
   });
-  const { data } = useTournamentInfo(tournamentId);
+  const { data } = useTournamentGameResultInfo(tournamentId);
   const ref = useRef<HTMLDivElement>(null);
-  const hasStarted = !!data?.tournament.startedAt;
-  const selected = selectedGameId === id;
+  const hasStarted = !!data?.hasStarted;
   const isActive = selected && hasStarted;
   const muted = result && !selected;
-  const isClosed = !!data?.tournament.closedAt;
-  const allowPlayersSetResults = !!data?.club.allowPlayersSetResults;
+  const isClosed = !!data?.isClosed;
+  const allowPlayersSetResults = !!data?.allowPlayersSetResults;
   // players can only edit their own games, and only after tournament has started
-  const isPlayerInGame =
-    playerId === playerLeft.whiteId || playerId === playerRight.blackId;
+  const isPlayerInGame = playerId === whiteId || playerId === blackId;
   const canEdit =
     status === 'organizer' ||
     (status === 'player' && isPlayerInGame && hasStarted);
@@ -79,8 +74,8 @@ const GameItem: FC<GameProps> = ({
     if (selected && hasStarted && !mutation.isPending) {
       mutation.mutate({
         gameId: id,
-        whiteId: playerLeft.whiteId,
-        blackId: playerRight.blackId,
+        whiteId,
+        blackId,
         result: newResult,
         prevResult: result,
         tournamentId,
@@ -123,9 +118,9 @@ const GameItem: FC<GameProps> = ({
             isWinner={result === '1-0'}
             handleMutate={() => handleMutate('1-0')}
             selected={isActive}
-            nickname={playerLeft.whiteNickname}
+            nickname={whiteNickname}
             position={{ justify: 'justify-self-start', text: 'text-left' }}
-            className={`${playerId === playerLeft.whiteId && 'font-bold'}`}
+            className={`${playerId === whiteId && 'font-bold'}`}
           />
           <Button
             variant="ghost"
@@ -138,9 +133,9 @@ const GameItem: FC<GameProps> = ({
             isWinner={result === '0-1'}
             handleMutate={() => handleMutate('0-1')}
             selected={isActive}
-            nickname={playerRight.blackNickname}
+            nickname={blackNickname}
             position={{ justify: 'justify-self-end', text: 'text-right' }}
-            className={`${playerId === playerRight.blackId && 'font-bold'}`}
+            className={`${playerId === blackId && 'font-bold'}`}
           />
         </Card>
       </motion.div>
@@ -151,9 +146,13 @@ const GameItem: FC<GameProps> = ({
 type GameProps = {
   id: string;
   result: GameResult | null;
-  playerLeft: Pick<GameModel, 'whiteId' | 'whiteNickname'>;
-  playerRight: Pick<GameModel, 'blackId' | 'blackNickname'>;
+  whiteId: string;
+  whiteNickname: string;
+  blackId: string;
+  blackNickname: string;
   roundNumber: number;
+  selected: boolean;
+  setSelectedGameId: Dispatch<SetStateAction<string | null>>;
 };
 
-export default GameItem;
+export default memo(GameItem);

--- a/src/app/tournaments/[id]/dashboard/tabs/games/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/index.tsx
@@ -8,7 +8,7 @@ import {
 import RoundControls from '@/app/tournaments/[id]/dashboard/tabs/games/round-controls';
 import RoundItem from '@/app/tournaments/[id]/dashboard/tabs/games/round-item';
 import StartTournamentDrawer from '@/app/tournaments/[id]/dashboard/tabs/games/start-tournament-drawer';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentGamesOverviewInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { useTournamentPlayers } from '@/components/hooks/query-hooks/use-tournament-players';
 import Overlay from '@/components/overlay';
 import SkeletonList from '@/components/skeleton-list';
@@ -24,7 +24,7 @@ const Games: FC = () => {
   const { selectedGameId } = useContext(SelectedGameContext);
   const queryClient = useQueryClient();
   const { id } = useParams<{ id: string }>();
-  const { data, isError, isLoading } = useTournamentInfo(id);
+  const { data, isError, isLoading } = useTournamentGamesOverviewInfo(id);
   const {
     data: players,
     isLoading: isPlayersloading,
@@ -33,9 +33,7 @@ const Games: FC = () => {
   const t = useTranslations('Tournament.Round');
   const trpc = useTRPC();
   const now = new Date().getTime();
-  const startedAt = data?.tournament.startedAt
-    ? data.tournament.startedAt.getTime()
-    : 0;
+  const startedAt = data?.startedAt ? data.startedAt.getTime() : 0;
   const renderDrawer = !startedAt || now - startedAt <= 5000;
 
   if (isError || isPlayersError) {
@@ -90,7 +88,7 @@ const Games: FC = () => {
       <RoundControls
         roundInView={roundInView}
         setRoundInView={setRoundInView}
-        currentRound={data.tournament.ongoingRound}
+        currentRound={data.ongoingRound}
         currentTab={currentTab}
       />
       <RoundItem roundNumber={roundInView} />

--- a/src/app/tournaments/[id]/dashboard/tabs/games/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/index.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardTabContext,
+  DashboardRoundContext,
+  SelectedGameContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import RoundControls from '@/app/tournaments/[id]/dashboard/tabs/games/round-controls';
 import RoundItem from '@/app/tournaments/[id]/dashboard/tabs/games/round-item';
 import StartTournamentDrawer from '@/app/tournaments/[id]/dashboard/tabs/games/start-tournament-drawer';
@@ -15,8 +19,9 @@ import { useParams } from 'next/navigation';
 import { FC, useContext } from 'react';
 
 const Games: FC = () => {
-  const { currentTab, roundInView, setRoundInView, selectedGameId } =
-    useContext(DashboardContext);
+  const { currentTab } = useContext(DashboardTabContext);
+  const { roundInView, setRoundInView } = useContext(DashboardRoundContext);
+  const { selectedGameId } = useContext(SelectedGameContext);
   const queryClient = useQueryClient();
   const { id } = useParams<{ id: string }>();
   const { data, isError, isLoading } = useTournamentInfo(id);

--- a/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
@@ -1,6 +1,10 @@
 'use client';
 import { LoadingSpinner } from '@/app/loading';
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardContext,
+  DashboardRoundContext,
+  SelectedGameContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import FinishTournamentButton from '@/app/tournaments/[id]/dashboard/finish-tournament-button';
 import GameItem from '@/app/tournaments/[id]/dashboard/tabs/games/game/game-item';
 import Center from '@/components/center';
@@ -22,7 +26,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ArrowRightIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-import { FC, useContext } from 'react';
+import { Dispatch, FC, SetStateAction, useContext } from 'react';
 
 const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
   const { id: tournamentId } = useParams<{ id: string }>();
@@ -37,6 +41,7 @@ const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
   const info = useTournamentInfo(tournamentId);
   const { data: players } = useTournamentPlayers(tournamentId);
   const { status } = useContext(DashboardContext);
+  const { selectedGameId, setSelectedGameId } = useContext(SelectedGameContext);
   const { sortedRound, ongoingGames } = useRoundData(round, players);
 
   if (isLoading || !info.data || !players)
@@ -69,8 +74,15 @@ const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
         renderFinishButton={renderFinishButton}
         format={format}
       />
-      {sortedRound.map((game, index) => {
-        return <GamesIteratee key={index} {...game} />;
+      {sortedRound.map((game) => {
+        return (
+          <GamesIteratee
+            key={game.id}
+            selected={selectedGameId === game.id}
+            setSelectedGameId={setSelectedGameId}
+            {...game}
+          />
+        );
       })}
     </div>
   );
@@ -98,7 +110,7 @@ const NewRoundButton: FC<{
   const t = useTranslations('Tournament.Round');
   const { data: tournamentGames } = useTournamentGames(tournamentId);
   const queryClient = useQueryClient();
-  const { setRoundInView } = useContext(DashboardContext);
+  const { setRoundInView } = useContext(DashboardRoundContext);
 
   const { mutate, isPending: mutating } = useSaveRound({
     isTournamentGoing: true,
@@ -171,13 +183,22 @@ const GamesIteratee = ({
   whiteId,
   blackId,
   roundNumber,
-}: GameModel) => (
+  selected,
+  setSelectedGameId,
+}: GameModel & {
+  selected: boolean;
+  setSelectedGameId: Dispatch<SetStateAction<string | null>>;
+}) => (
   <GameItem
     id={id}
     result={result}
-    playerLeft={{ whiteId, whiteNickname }}
-    playerRight={{ blackId, blackNickname }}
+    whiteId={whiteId}
+    whiteNickname={whiteNickname}
+    blackId={blackId}
+    blackNickname={blackNickname}
     roundNumber={roundNumber}
+    selected={selected}
+    setSelectedGameId={setSelectedGameId}
   />
 );
 

--- a/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
@@ -26,7 +26,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ArrowRightIcon } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-import { Dispatch, FC, SetStateAction, useContext } from 'react';
+import { Dispatch, FC, memo, SetStateAction, useContext } from 'react';
 
 const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
   const { id: tournamentId } = useParams<{ id: string }>();
@@ -175,7 +175,7 @@ const ActionButton = ({
   return null;
 };
 
-const GamesIteratee = ({
+const GamesIteratee = memo(function GamesIteratee({
   id,
   result,
   whiteNickname,
@@ -188,19 +188,21 @@ const GamesIteratee = ({
 }: GameModel & {
   selected: boolean;
   setSelectedGameId: Dispatch<SetStateAction<string | null>>;
-}) => (
-  <GameItem
-    id={id}
-    result={result}
-    whiteId={whiteId}
-    whiteNickname={whiteNickname}
-    blackId={blackId}
-    blackNickname={blackNickname}
-    roundNumber={roundNumber}
-    selected={selected}
-    setSelectedGameId={setSelectedGameId}
-  />
-);
+}) {
+  return (
+    <GameItem
+      id={id}
+      result={result}
+      whiteId={whiteId}
+      whiteNickname={whiteNickname}
+      blackId={blackId}
+      blackNickname={blackNickname}
+      roundNumber={roundNumber}
+      selected={selected}
+      setSelectedGameId={setSelectedGameId}
+    />
+  );
+});
 
 type RoundItemProps = {
   roundNumber: number;

--- a/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/round-item.tsx
@@ -10,7 +10,7 @@ import GameItem from '@/app/tournaments/[id]/dashboard/tabs/games/game/game-item
 import Center from '@/components/center';
 import useSaveRound from '@/components/hooks/mutation-hooks/use-tournament-save-round';
 import { useTournamentGames } from '@/components/hooks/query-hooks/_use-tournament-games';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentRoundProgressInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { useTournamentPlayers } from '@/components/hooks/query-hooks/use-tournament-players';
 import { useTournamentRoundGames } from '@/components/hooks/query-hooks/use-tournament-round-games';
 import { useRoundData } from '@/components/hooks/use-round-data';
@@ -38,7 +38,7 @@ const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
     tournamentId,
     roundNumber,
   });
-  const info = useTournamentInfo(tournamentId);
+  const info = useTournamentRoundProgressInfo(tournamentId);
   const { data: players } = useTournamentPlayers(tournamentId);
   const { status } = useContext(DashboardContext);
   const { selectedGameId, setSelectedGameId } = useContext(SelectedGameContext);
@@ -54,7 +54,7 @@ const RoundItem: FC<RoundItemProps> = ({ roundNumber }) => {
   if (isError) return <Center>error</Center>;
   if (!round) return <Center>no round</Center>;
 
-  const { ongoingRound, roundsNumber, closedAt, format } = info.data.tournament;
+  const { ongoingRound, roundsNumber, closedAt, format } = info.data;
   const renderFinishButton =
     status === 'organizer' && !closedAt && ongoingRound === roundsNumber;
   const renderNewRoundButton =

--- a/src/app/tournaments/[id]/dashboard/tabs/games/start-tournament-drawer.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/games/start-tournament-drawer.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardContext,
+  SelectedGameContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import StartTournamentButton from '@/app/tournaments/[id]/dashboard/tabs/main/start-tournament-button';
 import FormattedMessage from '@/components/formatted-message';
 import {
@@ -17,7 +20,8 @@ import { FC, useContext } from 'react';
 const StartTournamentDrawer: FC<{
   startedAt: number | undefined;
 }> = ({ startedAt }) => {
-  const { selectedGameId, status } = useContext(DashboardContext);
+  const { status } = useContext(DashboardContext);
+  const { selectedGameId } = useContext(SelectedGameContext);
   const open = !startedAt && !!selectedGameId && status === 'organizer';
 
   return (

--- a/src/app/tournaments/[id]/dashboard/tabs/main/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/index.tsx
@@ -19,7 +19,14 @@ import { Maximize2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { FC, useCallback, useContext, useState } from 'react';
+import {
+  ChangeEvent,
+  FC,
+  memo,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
 
 const Main: FC<{ toggleFullscreen?: () => void }> = ({ toggleFullscreen }) => {
   const { id: tournamentId } = useParams<{ id: string }>();
@@ -34,6 +41,13 @@ const Main: FC<{ toggleFullscreen?: () => void }> = ({ toggleFullscreen }) => {
 
   const { mutate } = useTournamentEditTitle();
 
+  const handleTitleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setControlledTitle(event.target.value);
+    },
+    [],
+  );
+
   const handleTitleUpdate = useCallback(() => {
     if (controlledTitle !== tournamentTitle)
       mutate({ tournamentId, title: controlledTitle });
@@ -45,24 +59,14 @@ const Main: FC<{ toggleFullscreen?: () => void }> = ({ toggleFullscreen }) => {
   return (
     <div className="px-mk md:px-mk-2 flex flex-col md:grid md:grid-cols-2">
       <div className="col-span-2">
-        <div
-          className={`p-mk flex items-center justify-between max-md:border-b md:pb-0`}
-        >
-          <InputGhost
-            disabled={!isOrganizer}
-            placeholder={fallbackTitle}
-            value={controlledTitle}
-            onBlur={handleTitleUpdate}
-            onChange={(event) => setControlledTitle(event.target.value)}
-            className={`text-3xl ${turboPascal.className} truncate`}
-          />
-          {isOrganizer && (
-            <DestructiveTournamentButtonsComboModal
-              tournament={data.tournament}
-              className="md:hidden"
-            />
-          )}
-        </div>
+        <TournamentTitle
+          controlledTitle={controlledTitle}
+          fallbackTitle={fallbackTitle}
+          handleTitleChange={handleTitleChange}
+          handleTitleUpdate={handleTitleUpdate}
+          isOrganizer={isOrganizer}
+          tournament={data.tournament}
+        />
       </div>
       <TournamentInfoList />
       <div className="flex w-full items-start justify-end md:col-span-1 md:items-end">
@@ -139,4 +143,43 @@ export const LoadingElement = () => {
   );
 };
 
-export default Main;
+const TournamentTitle = memo(function TournamentTitle({
+  controlledTitle,
+  fallbackTitle,
+  handleTitleChange,
+  handleTitleUpdate,
+  isOrganizer,
+  tournament,
+}: {
+  controlledTitle: string;
+  fallbackTitle: string;
+  handleTitleChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleTitleUpdate: () => void;
+  isOrganizer: boolean;
+  tournament: Parameters<
+    typeof DestructiveTournamentButtonsComboModal
+  >[0]['tournament'];
+}) {
+  return (
+    <div
+      className={`p-mk flex items-center justify-between max-md:border-b md:pb-0`}
+    >
+      <InputGhost
+        disabled={!isOrganizer}
+        placeholder={fallbackTitle}
+        value={controlledTitle}
+        onBlur={handleTitleUpdate}
+        onChange={handleTitleChange}
+        className={`text-3xl ${turboPascal.className} truncate`}
+      />
+      {isOrganizer && (
+        <DestructiveTournamentButtonsComboModal
+          tournament={tournament}
+          className="md:hidden"
+        />
+      )}
+    </div>
+  );
+});
+
+export default memo(Main);

--- a/src/app/tournaments/[id]/dashboard/tabs/main/reset-players-button.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/reset-players-button.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { LoadingSpinner } from '@/app/loading';
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardContext,
+  DashboardRoundContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import useTournamentResetPlayers from '@/components/hooks/mutation-hooks/use-tournament-reset-players';
 import {
   Close,
@@ -22,7 +25,8 @@ import { useContext, useState } from 'react';
 export default function ResetTournamentPButton() {
   const { id: tournamentId } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
-  const { sendJsonMessage, setRoundInView } = useContext(DashboardContext);
+  const { sendJsonMessage } = useContext(DashboardContext);
+  const { setRoundInView } = useContext(DashboardRoundContext);
   const { mutate, isPending } = useTournamentResetPlayers(
     queryClient,
     sendJsonMessage,

--- a/src/app/tournaments/[id]/dashboard/tabs/main/reset-tournament-button.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/reset-tournament-button.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { LoadingSpinner } from '@/app/loading';
-import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import {
+  DashboardContext,
+  DashboardRoundContext,
+} from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import useTournamentReset from '@/components/hooks/mutation-hooks/use-tournament-reset';
 import {
   Close,
@@ -26,7 +29,8 @@ export default function ResetTournamentButton({
 }) {
   const { id: tournamentId } = useParams<{ id: string }>();
   const queryClient = useQueryClient();
-  const { sendJsonMessage, setRoundInView } = useContext(DashboardContext);
+  const { sendJsonMessage } = useContext(DashboardContext);
+  const { setRoundInView } = useContext(DashboardRoundContext);
   const { mutate, isPending } = useTournamentReset(
     tournamentId,
     queryClient,

--- a/src/app/tournaments/[id]/dashboard/tabs/main/tournament-info.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/tournament-info.tsx
@@ -3,7 +3,7 @@ import {
   LoadingElement,
 } from '@/app/tournaments/[id]/dashboard/tabs/main';
 import Winners from '@/app/tournaments/[id]/dashboard/tabs/main/winners';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentSummaryInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import SwissRoundsNumber from '@/components/swiss-rounds-number';
 import {
   CalendarDays,
@@ -15,11 +15,12 @@ import {
 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
+import { memo } from 'react';
 import { toast } from 'sonner';
 
 const TournamentInfoList = () => {
   const { id: tournamentId } = useParams<{ id: string }>();
-  const { data, isLoading, isError } = useTournamentInfo(tournamentId);
+  const { data, isLoading, isError } = useTournamentSummaryInfo(tournamentId);
   const t = useTranslations('Tournament.Main');
   const locale = useLocale();
 
@@ -33,7 +34,7 @@ const TournamentInfoList = () => {
   }
   if (!data) return 'tournament info is `undefined` somehow';
 
-  const dateArr = data.tournament.date.split('-');
+  const dateArr = data.date.split('-');
   const formattedDate = new Date(
     Number(dateArr[0]),
     Number(dateArr[1]) - 1, // month is 0-indexed 2025-01-01 is (2025, 0, 1) = first of january
@@ -51,12 +52,12 @@ const TournamentInfoList = () => {
     <div className="md:text-muted-foreground gap-y-mk gap-x-mk-2 p-mk flex flex-col flex-wrap text-xs md:flex-row md:items-center">
       <InfoItem
         icon={HomeIcon}
-        value={data.club?.name}
-        href={`/clubs/${data.club?.id}`}
+        value={data.clubName}
+        href={`/clubs/${data.clubId}`}
       />
-      <InfoItem icon={UserRound} value={t(`Types.${data.tournament.type}`)} />
-      <InfoItem icon={Dices} value={data.tournament.format} format={true} />
-      {data.tournament.format === 'swiss' && (
+      <InfoItem icon={UserRound} value={t(`Types.${data.type}`)} />
+      <InfoItem icon={Dices} value={data.format} format={true} />
+      {data.format === 'swiss' && (
         <div className="flex items-center gap-2">
           <Layers className="text-muted-foreground size-4" />
           <span>{t('number of rounds')}</span>
@@ -65,12 +66,12 @@ const TournamentInfoList = () => {
       )}
       <InfoItem
         icon={ChartNoAxesCombinedIcon}
-        value={data.tournament.rated ? t('rated') : t('unrated')}
+        value={data.rated ? t('rated') : t('unrated')}
       />
       <InfoItem icon={CalendarDays} value={decapitalizedWeekday} />
-      <Winners {...data} />
+      <Winners tournamentId={data.tournamentId} closedAt={data.closedAt} />
     </div>
   );
 };
 
-export default TournamentInfoList;
+export default memo(TournamentInfoList);

--- a/src/app/tournaments/[id]/dashboard/tabs/main/winners.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/winners.tsx
@@ -2,15 +2,17 @@
 
 import { useTournamentPlayers } from '@/components/hooks/query-hooks/use-tournament-players';
 import { PlayerTournamentModel } from '@/server/zod/players';
-import { TournamentInfoModel } from '@/server/zod/tournaments';
 import Link from 'next/link';
 import { FC } from 'react';
 
-const Winners: FC<TournamentInfoModel> = ({ tournament }) => {
-  const { data: players } = useTournamentPlayers(tournament.id);
+const Winners: FC<{
+  closedAt: Date | null;
+  tournamentId: string;
+}> = ({ closedAt, tournamentId }) => {
+  const { data: players } = useTournamentPlayers(tournamentId);
   const winners = groupWinnersByPlace(players);
 
-  if (!winners || !tournament.closedAt) return null;
+  if (!winners || !closedAt) return null;
   return (
     <div className="flex flex-col gap-4 md:hidden">
       {Object.entries(winners).map(([place, players]) => (

--- a/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
@@ -8,7 +8,7 @@ import {
 import PlayerDrawer from '@/app/tournaments/[id]/dashboard/tabs/table/player-drawer';
 import { useTournamentRemovePlayer } from '@/components/hooks/mutation-hooks/use-tournament-remove-player';
 import { useTournamentWithdrawPlayer } from '@/components/hooks/mutation-hooks/use-tournament-withdraw-player';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentScoringInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { useTournamentPlayers } from '@/components/hooks/query-hooks/use-tournament-players';
 import {
   Table,
@@ -23,9 +23,12 @@ import { Scale, Trophy, UserRound } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
 import {
+  Dispatch,
   FC,
+  memo,
   PropsWithChildren,
   ReactNode,
+  SetStateAction,
   useContext,
   useMemo,
   useState,
@@ -44,7 +47,7 @@ import { UserModel } from '@/server/zod/users';
 const TournamentTable: FC = ({}) => {
   const { id } = useParams<{ id: string }>();
   const players = useTournamentPlayers(id);
-  const tournament = useTournamentInfo(id);
+  const tournament = useTournamentScoringInfo(id);
   const { status } = useContext(DashboardContext);
   const removePlayers = useTournamentRemovePlayer(id);
   const withdrawPlayer = useTournamentWithdrawPlayer(id);
@@ -52,10 +55,10 @@ const TournamentTable: FC = ({}) => {
   const t = useTranslations('Tournament.Table');
   const [selectedPlayer, setSelectedPlayer] =
     useState<PlayerTournamentModel | null>(null);
-  const hasStarted = !!tournament.data?.tournament.startedAt;
-  const hasEnded = !!tournament.data?.tournament.closedAt;
+  const hasStarted = !!tournament.data?.startedAt;
+  const hasEnded = !!tournament.data?.closedAt;
   const { data: user } = useAuth();
-  const type = tournament.data?.tournament.type;
+  const type = tournament.data?.type;
   const allGames = useTournamentGames(id);
 
   const {
@@ -71,8 +74,8 @@ const TournamentTable: FC = ({}) => {
       };
 
     const tournamentForScoring = {
-      format: tournament.data.tournament.format,
-      ongoingRound: hasStarted ? tournament.data.tournament.ongoingRound : 0,
+      format: tournament.data.format,
+      ongoingRound: hasStarted ? tournament.data.ongoingRound : 0,
     };
 
     return sortPlayersByResultsWithMaps(
@@ -83,6 +86,22 @@ const TournamentTable: FC = ({}) => {
   }, [players.data, tournament.data, allGames.data, hasStarted]);
 
   const stats: Stat[] = STATS_WITH_TIEBREAK;
+  const statRenderers = useMemo<
+    Record<Stat, (player: PlayerTournamentModel) => ReactNode>
+  >(
+    () => ({
+      wins: (p) => p.wins,
+      draws: (p) => p.draws,
+      losses: (p) => p.losses,
+      score: (p) => playerScoresMap.get(p.id),
+      tiebreak: (p) => (
+        <span className="text-muted-foreground">
+          {tiebreakScoresMap.get(p.id)}
+        </span>
+      ),
+    }),
+    [playerScoresMap, tiebreakScoresMap],
+  );
 
   if (players.isLoading || allGames.isLoading) {
     return <TableLoading stats={stats} />;
@@ -114,7 +133,7 @@ const TournamentTable: FC = ({}) => {
       status === 'organizer' &&
       hasStarted &&
       !hasEnded &&
-      tournament.data?.tournament.format === 'swiss' &&
+      tournament.data?.format === 'swiss' &&
       selectedPlayer &&
       !selectedPlayer.isOut
     ) {
@@ -127,21 +146,6 @@ const TournamentTable: FC = ({}) => {
         { onSuccess: () => setSelectedPlayer(null) },
       );
     }
-  };
-
-  const statRenderers: Record<
-    Stat,
-    (player: PlayerTournamentModel) => ReactNode
-  > = {
-    wins: (p) => p.wins,
-    draws: (p) => p.draws,
-    losses: (p) => p.losses,
-    score: (p) => playerScoresMap.get(p.id),
-    tiebreak: (p) => (
-      <span className="text-muted-foreground">
-        {tiebreakScoresMap.get(p.id)}
-      </span>
-    ),
   };
 
   const nameColumnIntl = type !== 'solo' ? 'name column team' : 'name column';
@@ -164,25 +168,17 @@ const TournamentTable: FC = ({}) => {
         </TableHeader>
         <TableBody>
           {sortedPlayers.map((player: PlayerTournamentModel, i: number) => (
-            <TableRow
+            <PlayerRow
               key={player.id}
-              onClick={() => setSelectedPlayer(player)}
-              className={`${player.username === user?.username && 'bg-card/50 font-bold'}`}
-            >
-              <TableCellStyled className={`font-small w-10 text-center`}>
-                <Place player={player} hasEnded={hasEnded}>
-                  {i + 1}
-                </Place>
-              </TableCellStyled>
-              <TableCellStyled className="font-small max-w-0 truncate pl-0">
-                <Status player={player} user={user}>
-                  {player.nickname}
-                </Status>
-              </TableCellStyled>
-              {stats.map((stat) => (
-                <Stat key={stat}>{statRenderers[stat](player)}</Stat>
-              ))}
-            </TableRow>
+              hasEnded={hasEnded}
+              index={i}
+              isSelected={selectedPlayer?.id === player.id}
+              player={player}
+              renderStat={statRenderers}
+              setSelectedPlayer={setSelectedPlayer}
+              stats={stats}
+              user={user}
+            />
           ))}
         </TableBody>
       </Table>
@@ -195,12 +191,58 @@ const TournamentTable: FC = ({}) => {
           handleWithdraw={handleWithdraw}
           hasStarted={hasStarted}
           hasEnded={hasEnded}
-          format={tournament.data?.tournament.format ?? 'swiss'}
+          format={tournament.data?.format ?? 'swiss'}
         />
       )}
     </div>
   );
 };
+
+const PlayerRow = memo(function PlayerRow({
+  hasEnded,
+  index,
+  isSelected,
+  player,
+  renderStat,
+  setSelectedPlayer,
+  stats,
+  user,
+}: {
+  hasEnded: boolean;
+  index: number;
+  isSelected: boolean;
+  player: PlayerTournamentModel;
+  renderStat: Record<Stat, (player: PlayerTournamentModel) => ReactNode>;
+  setSelectedPlayer: Dispatch<SetStateAction<PlayerTournamentModel | null>>;
+  stats: Stat[];
+  user: UserModel | null | undefined;
+}) {
+  return (
+    <TableRow
+      onClick={() => setSelectedPlayer(player)}
+      className={[
+        player.username === user?.username ? 'bg-card/50 font-bold' : '',
+        isSelected ? 'bg-card/70' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <TableCellStyled className="font-small w-10 text-center">
+        <Place player={player} hasEnded={hasEnded}>
+          {index + 1}
+        </Place>
+      </TableCellStyled>
+      <TableCellStyled className="font-small max-w-0 truncate pl-0">
+        <Status player={player} user={user}>
+          {player.nickname}
+        </Status>
+      </TableCellStyled>
+      {stats.map((stat) => (
+        <Stat key={stat}>{renderStat[stat](player)}</Stat>
+      ))}
+    </TableRow>
+  );
+});
 
 const TableStatsHeads: FC<{ stats: Stat[] }> = ({ stats }) => {
   return (
@@ -348,4 +390,4 @@ type Stat =
   | 'score'
   | 'tiebreak';
 
-export default TournamentTable;
+export default memo(TournamentTable);

--- a/src/components/hooks/query-hooks/use-tournament-info.ts
+++ b/src/components/hooks/query-hooks/use-tournament-info.ts
@@ -5,3 +5,57 @@ export const useTournamentInfo = (tournamentId: string) => {
   const trpc = useTRPC();
   return useQuery(trpc.tournament.info.queryOptions({ tournamentId }));
 };
+
+export const useTournamentGameResultInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      allowPlayersSetResults: !!data.club.allowPlayersSetResults,
+      hasStarted: !!data.tournament.startedAt,
+      isClosed: !!data.tournament.closedAt,
+    }),
+  });
+};
+
+export const useTournamentSummaryInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      clubId: data.club?.id,
+      clubName: data.club?.name,
+      closedAt: data.tournament.closedAt,
+      date: data.tournament.date,
+      format: data.tournament.format,
+      rated: data.tournament.rated,
+      tournamentId: data.tournament.id,
+      type: data.tournament.type,
+    }),
+  });
+};
+
+export const useTournamentScoringInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      closedAt: data.tournament.closedAt,
+      format: data.tournament.format,
+      ongoingRound: data.tournament.ongoingRound,
+      startedAt: data.tournament.startedAt,
+      type: data.tournament.type,
+    }),
+  });
+};
+
+export const useTournamentSwissRoundsInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      closedAt: data.tournament.closedAt,
+      roundsNumber: data.tournament.roundsNumber,
+    }),
+  });
+};

--- a/src/components/hooks/query-hooks/use-tournament-info.ts
+++ b/src/components/hooks/query-hooks/use-tournament-info.ts
@@ -49,6 +49,30 @@ export const useTournamentScoringInfo = (tournamentId: string) => {
   });
 };
 
+export const useTournamentGamesOverviewInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      ongoingRound: data.tournament.ongoingRound,
+      startedAt: data.tournament.startedAt,
+    }),
+  });
+};
+
+export const useTournamentRoundProgressInfo = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.info.queryOptions({ tournamentId }),
+    select: (data) => ({
+      closedAt: data.tournament.closedAt,
+      format: data.tournament.format,
+      ongoingRound: data.tournament.ongoingRound,
+      roundsNumber: data.tournament.roundsNumber,
+    }),
+  });
+};
+
 export const useTournamentSwissRoundsInfo = (tournamentId: string) => {
   const trpc = useTRPC();
   return useQuery({

--- a/src/components/hooks/query-hooks/use-tournament-players.ts
+++ b/src/components/hooks/query-hooks/use-tournament-players.ts
@@ -5,3 +5,11 @@ export const useTournamentPlayers = (tournamentId: string) => {
   const trpc = useTRPC();
   return useQuery(trpc.tournament.playersIn.queryOptions({ tournamentId }));
 };
+
+export const useTournamentActivePlayersCount = (tournamentId: string) => {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.tournament.playersIn.queryOptions({ tournamentId }),
+    select: (players) => players.filter((player) => !player.isOut).length,
+  });
+};

--- a/src/components/swiss-rounds-number.tsx
+++ b/src/components/swiss-rounds-number.tsx
@@ -2,8 +2,8 @@
 
 import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import useSaveRoundsNumberMutation from '@/components/hooks/mutation-hooks/use-tournament-update-swiss-rounds-number';
-import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
-import { useTournamentPlayers } from '@/components/hooks/query-hooks/use-tournament-players';
+import { useTournamentSwissRoundsInfo } from '@/components/hooks/query-hooks/use-tournament-info';
+import { useTournamentActivePlayersCount } from '@/components/hooks/query-hooks/use-tournament-players';
 import { cn, getSwissMaxRoundsNumber } from '@/lib/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
@@ -17,16 +17,16 @@ export default function SwissRoundsNumber({
   className,
 }: SwissRoundsNumberProps) {
   const { id: tournamentId } = useParams<{ id: string }>();
-  const { data } = useTournamentInfo(tournamentId);
-  const { data: players } = useTournamentPlayers(tournamentId);
+  const { data } = useTournamentSwissRoundsInfo(tournamentId);
+  const { data: playerCount = 0 } =
+    useTournamentActivePlayersCount(tournamentId);
   const queryClient = useQueryClient();
   const { sendJsonMessage, status } = useContext(DashboardContext);
   const { mutate } = useSaveRoundsNumberMutation(queryClient, sendJsonMessage);
 
   const isOrganizer = status === 'organizer';
-  const isFinished = !!data?.tournament.closedAt;
-  const currentValue = data?.tournament.roundsNumber ?? 1;
-  const playerCount = players?.filter((player) => !player.isOut)?.length ?? 0;
+  const isFinished = !!data?.closedAt;
+  const currentValue = data?.roundsNumber ?? 1;
   const minValue = 1;
   const maxValue = getSwissMaxRoundsNumber(playerCount);
   const boundedCurrentValue = Math.min(


### PR DESCRIPTION
- split dashboard context into smaller providers so tab, round, and selected-game updates do not rerender unrelated consumers.
- narrow tournament/player query subscriptions with React Query selectors for dashboard sections.
- memoize heavier dashboard title, game, and table row rendering paths

Made with [Cursor](https://cursor.com)