### PR TITLE
Fix/pre start races

### DIFF
--- a/src/app/tournaments/[id]/dashboard/shuffle-button.tsx
+++ b/src/app/tournaments/[id]/dashboard/shuffle-button.tsx
@@ -1,6 +1,7 @@
 import { LoadingSpinner } from '@/app/loading';
 import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
 import Fab from '@/components/fab';
+import { useTournamentPreStartLocked } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked';
 import { useTournamentReorderUnits } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-reorder-units';
 import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { useTournamentRoundGames } from '@/components/hooks/query-hooks/use-tournament-round-games';
@@ -21,6 +22,8 @@ const ShuffleButton = () => {
   const { isPending, handleClick, tournament, units, games } = useShuffle();
   const { userId, status } = useContext(DashboardContext);
   const { isDesktop } = useContext(MediaQueryContext);
+  const { id: tournamentId } = useParams<{ id: string }>();
+  const preStartLocked = useTournamentPreStartLocked(tournamentId);
 
   if (
     tournament?.tournament.startedAt ||
@@ -36,7 +39,7 @@ const ShuffleButton = () => {
   const desktop = isSufficient ? (
     <Button
       onClick={handleClick}
-      disabled={isPending}
+      disabled={isPending || preStartLocked}
       size="icon-lg"
       variant="outline"
     >
@@ -46,7 +49,7 @@ const ShuffleButton = () => {
 
   const mobile = (
     <Fab
-      disabled={isPending || !isSufficient}
+      disabled={isPending || preStartLocked || !isSufficient}
       icon={!isPending ? Shuffle : Loader2}
       onClick={handleClick}
     />

--- a/src/app/tournaments/[id]/dashboard/tabs/main/reset-players-button.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/reset-players-button.tsx
@@ -31,6 +31,7 @@ export default function ResetTournamentPButton() {
     queryClient,
     sendJsonMessage,
     setRoundInView,
+    tournamentId,
   );
   const [open, setOpen] = useState(false);
   const t = useTranslations('Tournament.Main');

--- a/src/app/tournaments/[id]/dashboard/tabs/main/start-tournament-button.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/main/start-tournament-button.tsx
@@ -1,5 +1,5 @@
-import { AppError } from '@/lib/errors';
 import { DashboardContext } from '@/app/tournaments/[id]/dashboard/dashboard-context';
+import { useTournamentPreStartLocked } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked';
 import useTournamentStart from '@/components/hooks/mutation-hooks/use-tournament-start';
 import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { useTournamentUnits } from '@/components/hooks/query-hooks/use-tournament-units';
@@ -22,18 +22,11 @@ export default function StartTournamentButton() {
     id,
     sendJsonMessage,
   );
+  const preStartLocked = useTournamentPreStartLocked(id);
   const t = useTranslations('Tournament.Main');
 
   const handleClick = () => {
-    if (!units) {
-      throw new AppError('NO_UNITS_DATA');
-    }
-    if (!data) {
-      throw new AppError('NO_TOURNAMENT_DATA');
-    }
-    if (units.length < 2) {
-      throw new AppError('NOT_ENOUGH_TOURNAMENT_UNITS');
-    }
+    if (!data) return;
     startTournamentMutation.mutate(
       {
         startedAt: new Date(),
@@ -47,7 +40,7 @@ export default function StartTournamentButton() {
             tournament_id: data.tournament.id,
             format: data.tournament.format,
             rounds_number: data.tournament.roundsNumber,
-            unit_count: units.length,
+            unit_count: units?.length,
           });
         },
       },
@@ -57,17 +50,11 @@ export default function StartTournamentButton() {
   return (
     <Button
       className="isolate-touch md:col-span-2"
-      disabled={
-        !units || units?.length < 2 || startTournamentMutation.isPending
-      }
+      disabled={!units || units?.length < 2 || preStartLocked || !data}
       onClick={handleClick}
       size="lg"
     >
-      {startTournamentMutation.isPending ? (
-        <Loader2 className="animate-spin" />
-      ) : (
-        <CirclePlay />
-      )}
+      {preStartLocked ? <Loader2 className="animate-spin" /> : <CirclePlay />}
       {t('start tournament')}
     </Button>
   );

--- a/src/app/tournaments/[id]/dashboard/tabs/table/add-player/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/add-player/index.tsx
@@ -3,6 +3,7 @@ import AddDoublesUnit from '@/app/tournaments/[id]/dashboard/tabs/table/add-play
 import AddUnitDrawerContent from '@/app/tournaments/[id]/dashboard/tabs/table/add-player/add-unit-drawer-content';
 import Fab from '@/components/fab';
 import FormattedMessage from '@/components/formatted-message';
+import { useTournamentPreStartLocked } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked';
 import { useTournamentInfo } from '@/components/hooks/query-hooks/use-tournament-info';
 import { MediaQueryContext } from '@/components/providers/media-query-context';
 import SideDrawer from '@/components/ui-custom/side-drawer';
@@ -20,12 +21,13 @@ const AddUnitDrawer = () => {
   const [isAnimating, setIsAnimating] = useState(false);
   const { status } = useContext(DashboardContext);
   const { isDesktop } = useContext(MediaQueryContext);
+  const preStartLocked = useTournamentPreStartLocked(tournamentId);
 
   useHotkeys(
     'shift+equal',
     (e) => {
       e.preventDefault();
-      setOpen((prev) => !prev);
+      if (!preStartLocked) setOpen((prev) => !prev);
     },
     { enableOnFormTags: true },
   );
@@ -33,6 +35,7 @@ const AddUnitDrawer = () => {
     'control+shift+equal',
     (e) => {
       e.preventDefault();
+      if (preStartLocked) return;
       setOpen((prev) => !prev);
       setAddingNewPlayer(true);
     },
@@ -40,7 +43,7 @@ const AddUnitDrawer = () => {
   );
 
   const handleChange = (state: boolean) => {
-    if (!isAnimating) {
+    if (!isAnimating && (!preStartLocked || !state)) {
       setOpen(state);
       setAddingNewPlayer(false);
       setValue('');
@@ -60,6 +63,7 @@ const AddUnitDrawer = () => {
     <Button
       variant="outline"
       className="size-10 lg:w-fit"
+      disabled={preStartLocked}
       onClick={() => handleChange(!open)}
     >
       <UserPlus />
@@ -71,6 +75,7 @@ const AddUnitDrawer = () => {
     <Fab
       container={open || isAnimating ? document.body : undefined}
       className={`${(open || isAnimating) && 'z-60 md:hidden'}`}
+      disabled={preStartLocked}
       onClick={() => handleChange(!open)}
       icon={open ? X : UserPlus}
     />

--- a/src/app/tournaments/[id]/dashboard/tabs/table/destructive-buttons.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/destructive-buttons.tsx
@@ -13,11 +13,13 @@ import { UnitModel } from '@/server/zod/tournaments';
 import { LogOut, Trash2 } from 'lucide-react';
 import { FC } from 'react';
 
-export const DeleteButton: FC<{ handleDelete: () => void }> = ({
-  handleDelete,
-}) => (
+export const DeleteButton: FC<{
+  disabled?: boolean;
+  handleDelete: () => void;
+}> = ({ disabled, handleDelete }) => (
   <Button
     className="flex gap-2"
+    disabled={disabled}
     size="lg"
     variant="destructive"
     onClick={handleDelete}

--- a/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
@@ -14,6 +14,7 @@ import {
 import UnitDrawer from '@/app/tournaments/[id]/dashboard/tabs/table/unit-drawer';
 import { useSortableUnitTable } from '@/app/tournaments/[id]/dashboard/tabs/table/use-sortable-unit-table';
 import { useTournamentRemoveUnit } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-remove-unit';
+import { useTournamentPreStartLocked } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked';
 import { useTournamentWithdrawUnit } from '@/components/hooks/mutation-hooks/use-tournament-withdraw-unit';
 import { useTournamentGames } from '@/components/hooks/query-hooks/use-tournament-games';
 import { useTournamentScoringInfo } from '@/components/hooks/query-hooks/use-tournament-info';
@@ -54,6 +55,7 @@ const TournamentTable = () => {
   const { status, userId } = useContext(DashboardContext);
   const removeUnit = useTournamentRemoveUnit(id);
   const withdrawUnit = useTournamentWithdrawUnit(id);
+  const preStartLocked = useTournamentPreStartLocked(id);
   const t = useTranslations('Tournament.Table');
   const { translateError } = useIntlError();
   const [selectedUnit, setSelectedUnit] = useState<UnitModel | null>(null);
@@ -63,7 +65,7 @@ const TournamentTable = () => {
   const type = tournament.data?.type;
   const allGames = useTournamentGames(id);
   const stats = STATS_WITH_TIEBREAK;
-  const canSort = status === 'organizer' && !hasStarted;
+  const canSort = status === 'organizer' && !hasStarted && !preStartLocked;
 
   const {
     units: sortedUnits,
@@ -130,7 +132,13 @@ const TournamentTable = () => {
   }
 
   const handleDelete = () => {
-    if (userId && status === 'organizer' && !hasStarted && selectedUnit) {
+    if (
+      userId &&
+      status === 'organizer' &&
+      !hasStarted &&
+      !preStartLocked &&
+      selectedUnit
+    ) {
       removeUnit.mutate(
         {
           tournamentId: id,
@@ -235,6 +243,7 @@ const TournamentTable = () => {
           hasStarted={hasStarted}
           hasEnded={hasEnded}
           format={tournament.data?.format ?? 'swiss'}
+          preStartLocked={preStartLocked}
         />
       )}
     </div>

--- a/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
@@ -58,7 +58,7 @@ const TournamentTable = () => {
   const preStartLocked = useTournamentPreStartLocked(id);
   const t = useTranslations('Tournament.Table');
   const { translateError } = useIntlError();
-  const [selectedUnit, setSelectedUnit] = useState<UnitModel | null>(null);
+  const [selectedUnitId, setSelectedUnitId] = useState<string | null>(null);
   const hasStarted = !!tournament.data?.startedAt;
   const hasEnded = !!tournament.data?.closedAt;
   const { data: user } = useAuth();
@@ -110,6 +110,14 @@ const TournamentTable = () => {
   const { activeUnit, activeUnitId, handleDragStart, handleDragEnd } =
     useSortableUnitTable(sortedUnits, canSort);
 
+  const selectedUnit = useMemo(
+    () =>
+      selectedUnitId
+        ? (sortedUnits.find((unit) => unit.id === selectedUnitId) ?? null)
+        : null,
+    [selectedUnitId, sortedUnits],
+  );
+
   if (
     units.isLoading ||
     tournament.isLoading ||
@@ -139,14 +147,11 @@ const TournamentTable = () => {
       !preStartLocked &&
       selectedUnit
     ) {
-      removeUnit.mutate(
-        {
-          tournamentId: id,
-          unitId: selectedUnit.id,
-          userId,
-        },
-        { onSuccess: () => setSelectedUnit(null) },
-      );
+      removeUnit.mutate({
+        tournamentId: id,
+        unitId: selectedUnit.id,
+        userId,
+      });
     }
   };
 
@@ -160,14 +165,11 @@ const TournamentTable = () => {
       selectedUnit &&
       !selectedUnit.isOut
     ) {
-      withdrawUnit.mutate(
-        {
-          tournamentId: id,
-          unitId: selectedUnit.id,
-          userId,
-        },
-        { onSuccess: () => setSelectedUnit(null) },
-      );
+      withdrawUnit.mutate({
+        tournamentId: id,
+        unitId: selectedUnit.id,
+        userId,
+      });
     }
   };
 
@@ -198,10 +200,10 @@ const TournamentTable = () => {
                 canSort={canSort}
                 hasEnded={hasEnded}
                 index={index}
-                isSelected={selectedUnit?.id === unit.id}
+                isSelected={selectedUnitId === unit.id}
                 unit={unit}
                 renderStat={statRenderers}
-                setSelectedUnit={setSelectedUnit}
+                setSelectedUnitId={setSelectedUnitId}
                 stats={stats}
                 user={user}
               />
@@ -235,9 +237,8 @@ const TournamentTable = () => {
       </DragDropProvider>
       {selectedUnit && (
         <UnitDrawer
-          key={selectedUnit.id}
           unit={selectedUnit}
-          setSelectedUnit={setSelectedUnit}
+          onClose={() => setSelectedUnitId(null)}
           handleDelete={handleDelete}
           handleWithdraw={handleWithdraw}
           hasStarted={hasStarted}
@@ -257,7 +258,7 @@ const SortableUnitRow = memo(function SortableUnitRow({
   isSelected,
   unit,
   renderStat,
-  setSelectedUnit,
+  setSelectedUnitId,
   stats,
   user,
 }: {
@@ -267,7 +268,7 @@ const SortableUnitRow = memo(function SortableUnitRow({
   isSelected: boolean;
   unit: UnitModel;
   renderStat: Record<Stat, (unit: UnitModel) => ReactNode>;
-  setSelectedUnit: Dispatch<SetStateAction<UnitModel | null>>;
+  setSelectedUnitId: Dispatch<SetStateAction<string | null>>;
   stats: Stat[];
   user: UserModel | null | undefined;
 }) {
@@ -279,7 +280,7 @@ const SortableUnitRow = memo(function SortableUnitRow({
       isSelected={isSelected}
       onSelect={() => {
         if (!window.getSelection()?.isCollapsed) return;
-        setSelectedUnit(unit);
+        setSelectedUnitId(unit.id);
       }}
       unit={unit}
       renderStat={renderStat}

--- a/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
@@ -237,6 +237,7 @@ const TournamentTable = () => {
       </DragDropProvider>
       {selectedUnit && (
         <UnitDrawer
+          key={selectedUnit.id}
           unit={selectedUnit}
           onClose={() => setSelectedUnitId(null)}
           handleDelete={handleDelete}

--- a/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/index.tsx
@@ -13,8 +13,8 @@ import {
 } from '@/app/tournaments/[id]/dashboard/tabs/table/table-ui';
 import UnitDrawer from '@/app/tournaments/[id]/dashboard/tabs/table/unit-drawer';
 import { useSortableUnitTable } from '@/app/tournaments/[id]/dashboard/tabs/table/use-sortable-unit-table';
-import { useTournamentRemoveUnit } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-remove-unit';
 import { useTournamentPreStartLocked } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked';
+import { useTournamentRemoveUnit } from '@/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-remove-unit';
 import { useTournamentWithdrawUnit } from '@/components/hooks/mutation-hooks/use-tournament-withdraw-unit';
 import { useTournamentGames } from '@/components/hooks/query-hooks/use-tournament-games';
 import { useTournamentScoringInfo } from '@/components/hooks/query-hooks/use-tournament-info';
@@ -180,7 +180,7 @@ const TournamentTable = () => {
           <TableHeader className="bg-background/50 sticky top-0 backdrop-blur-md">
             <TableRow>
               {canSort && <TableHead className="w-6">&nbsp;</TableHead>}
-              <TableHead className="h-11 w-6 p-0 text-center">#</TableHead>
+              <TableHead className="h-11 min-w-6 p-0 text-center">#</TableHead>
               <TableHead className="h-11 w-full min-w-10 p-0">
                 {t.rich(nameColumnIntl, {
                   count: units.data?.length ?? 0,

--- a/src/app/tournaments/[id]/dashboard/tabs/table/unit-drawer.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/unit-drawer.tsx
@@ -36,6 +36,7 @@ const UnitDrawer: FC<{
   hasEnded: boolean;
   hasStarted: boolean;
   format: TournamentFormat;
+  preStartLocked: boolean;
 }> = ({
   unit,
   setSelectedUnit,
@@ -44,6 +45,7 @@ const UnitDrawer: FC<{
   handleDelete,
   handleWithdraw,
   format,
+  preStartLocked,
 }) => {
   const open = !!unit;
   const { status } = useContext(DashboardContext);
@@ -56,7 +58,11 @@ const UnitDrawer: FC<{
   const closeDrawer = () => setSelectedUnit(null);
   const comboOpen = open && !isEditingUnit;
   const canEditUnit =
-    status === 'organizer' && !hasStarted && !hasEnded && isDoublesUnit;
+    status === 'organizer' &&
+    !hasStarted &&
+    !hasEnded &&
+    !preStartLocked &&
+    isDoublesUnit;
   const editInitialValues: DoublesUnitInitialValues | null =
     unit.players.length === 2
       ? {
@@ -130,6 +136,7 @@ const UnitDrawer: FC<{
               handleDelete={handleDelete}
               handleWithdraw={handleWithdraw}
               closeDrawer={closeDrawer}
+              preStartLocked={preStartLocked}
             />
           )}
 
@@ -180,6 +187,7 @@ const DestructiveButton = ({
   closeDrawer,
   unit,
   format,
+  preStartLocked,
 }: {
   hasEnded: boolean;
   hasStarted: boolean;
@@ -188,6 +196,7 @@ const DestructiveButton = ({
   closeDrawer: () => void;
   unit: UnitModel;
   format: TournamentFormat;
+  preStartLocked: boolean;
 }) => {
   if (hasEnded) return null;
   if (hasStarted && format === 'swiss' && !unit.isOut) {
@@ -204,6 +213,7 @@ const DestructiveButton = ({
   if (hasStarted) return null;
   return (
     <DeleteButton
+      disabled={preStartLocked}
       handleDelete={() => {
         closeDrawer();
         handleDelete();

--- a/src/app/tournaments/[id]/dashboard/tabs/table/unit-drawer.tsx
+++ b/src/app/tournaments/[id]/dashboard/tabs/table/unit-drawer.tsx
@@ -30,7 +30,7 @@ import { FC, useContext, useState } from 'react';
 
 const UnitDrawer: FC<{
   unit: UnitModel;
-  setSelectedUnit: (_arg: null) => void;
+  onClose: () => void;
   handleDelete: () => void;
   handleWithdraw: () => void;
   hasEnded: boolean;
@@ -39,7 +39,7 @@ const UnitDrawer: FC<{
   preStartLocked: boolean;
 }> = ({
   unit,
-  setSelectedUnit,
+  onClose,
   hasEnded,
   hasStarted,
   handleDelete,
@@ -55,7 +55,7 @@ const UnitDrawer: FC<{
   const isDoublesUnit = unit.players.length === 2;
   const [isEditingUnit, setIsEditingUnit] = useState(false);
 
-  const closeDrawer = () => setSelectedUnit(null);
+  const closeDrawer = onClose;
   const comboOpen = open && !isEditingUnit;
   const canEditUnit =
     status === 'organizer' &&

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-shared-pre-start.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-shared-pre-start.ts
@@ -45,7 +45,14 @@ export const useSharedPreStart = (tournamentId: string) => {
   const invalidatePreStartState = (
     options: { playersOut?: boolean; info?: boolean; allGames?: boolean } = {},
   ) => {
-    if (queryClient.isMutating() !== 1) return;
+    if (
+      queryClient.isMutating({
+        predicate: (mutation) =>
+          mutation.options.scope?.id === `tournament-pre-start:${tournamentId}`,
+      }) !== 1
+    ) {
+      return;
+    }
 
     queryClient.invalidateQueries({ queryKey: keys.roundGames });
     if (options.playersOut) {

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-shared-pre-start.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-shared-pre-start.ts
@@ -45,7 +45,7 @@ export const useSharedPreStart = (tournamentId: string) => {
   const invalidatePreStartState = (
     options: { playersOut?: boolean; info?: boolean; allGames?: boolean } = {},
   ) => {
-    if (!optimisticPreStartRound.isOnlyPendingPreStartRoundMutation()) return;
+    if (queryClient.isMutating() !== 1) return;
 
     queryClient.invalidateQueries({ queryKey: keys.roundGames });
     if (options.playersOut) {

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-doubles-unit.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-doubles-unit.ts
@@ -28,6 +28,7 @@ export const useTournamentAddDoublesUnit = (tournamentId: string) => {
 
   return useMutation(
     trpc.tournament.addDoublesUnit.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       async onMutate(data) {
         data.unitId ??= newid();
         const { unitId, nickname, firstPlayerId, secondPlayerId, addedAt } =

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-existing-player.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-existing-player.ts
@@ -25,6 +25,7 @@ export const useTournamentAddExistingPlayer = (tournamentId: string) => {
 
   return useMutation(
     trpc.tournament.addSoloUnit.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       onMutate: async (data) => {
         data.unitId ??= newid();
         const { unitId, player, addedAt } = data;

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-new-player.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-add-new-player.ts
@@ -28,6 +28,7 @@ export const useTournamentAddNewPlayer = (
 
   return useMutation(
     trpc.tournament.addNewSoloUnit.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       onMutate: async (data) => {
         data.unitId ??= newid();
         data.player.id ??= newid();

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-edit-doubles-unit.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-edit-doubles-unit.ts
@@ -27,6 +27,7 @@ export const useTournamentEditDoublesUnit = (tournamentId: string) => {
 
   return useMutation(
     trpc.tournament.editDoublesUnit.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       async onMutate({ unitId, nickname, firstPlayerId, secondPlayerId }) {
         await queryClient.cancelQueries({ queryKey: keys.playersOut });
 

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-pre-start-locked.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useTRPC } from '@/components/trpc/client';
+import { useIsMutating } from '@tanstack/react-query';
+
+export const useTournamentPreStartLocked = (tournamentId: string) => {
+  const trpc = useTRPC();
+
+  return (
+    useIsMutating({
+      mutationKey: trpc.tournament.start.mutationKey(),
+      predicate: (mutation) =>
+        mutation.options.scope?.id === `tournament-pre-start:${tournamentId}`,
+    }) > 0
+  );
+};

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-remove-unit.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-remove-unit.ts
@@ -20,6 +20,7 @@ export const useTournamentRemoveUnit = (tournamentId: string) => {
 
   return useMutation(
     trpc.tournament.removeUnit.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       onMutate: async ({ unitId }) => {
         await queryClient.cancelQueries({ queryKey: keys.playersOut });
         const previousUnits = queryClient.getQueryData<UnitModel[]>(keys.units);

--- a/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-reorder-units.ts
+++ b/src/components/hooks/mutation-hooks/tournament-pre-start-hooks/use-tournament-reorder-units.ts
@@ -40,6 +40,7 @@ export const useTournamentReorderUnits = (tournamentId: string) => {
   const mutationOptions = trpc.tournament.reorderUnits.mutationOptions();
   return useMutation({
     ...mutationOptions,
+    scope: { id: `tournament-pre-start:${tournamentId}` },
     onMutate: ({ unitIds }) => applyReorderOptimistically(unitIds),
     onError: (_error, _variables, context) => {
       rollbackOptimisticPreStartRound(context);

--- a/src/components/hooks/mutation-hooks/use-tournament-reset-players.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-reset-players.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { getAppErrorMessage } from '@/lib/errors';
 import { useTRPC } from '@/components/trpc/client';
+import { getAppErrorMessage } from '@/lib/errors';
 import { DashboardMessage } from '@/types/tournament-ws-events';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
@@ -12,13 +12,19 @@ export default function useTournamentResetPlayers(
   queryClient: QueryClient,
   sendJsonMessage: (_message: DashboardMessage) => void,
   setRoundInView: Dispatch<SetStateAction<number>>,
+  tournamentId: string,
 ) {
   const tErrors = useTranslations('Errors');
   const trpc = useTRPC();
   return useMutation(
     trpc.tournament.resetPlayers.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       onSuccess: () => {
-        sendJsonMessage({ event: 'reset-tournament' });
+        sendJsonMessage({ event: 'reset-tournament-players' });
+        queryClient.setQueryData(
+          trpc.tournament.units.queryKey({ tournamentId }),
+          [],
+        );
         queryClient.invalidateQueries({
           queryKey: trpc.tournament.pathKey(),
         });

--- a/src/components/hooks/mutation-hooks/use-tournament-start.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-start.ts
@@ -17,6 +17,7 @@ export default function useTournamentStart(
   const trpc = useTRPC();
   return useMutation(
     trpc.tournament.start.mutationOptions({
+      scope: { id: `tournament-pre-start:${tournamentId}` },
       onSuccess: (games, { startedAt }) => {
         if (startedAt) {
           toast.success(t('started'));

--- a/src/components/hooks/mutation-hooks/use-tournament-start.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-start.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { getAppErrorMessage } from '@/lib/errors';
 import { useTRPC } from '@/components/trpc/client';
+import { getAppErrorMessage } from '@/lib/errors';
 import { DashboardMessage } from '@/types/tournament-ws-events';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
@@ -21,6 +21,19 @@ export default function useTournamentStart(
       onSuccess: (games, { startedAt }) => {
         if (startedAt) {
           toast.success(t('started'));
+          queryClient.setQueryData(
+            trpc.tournament.info.queryKey({ tournamentId }),
+            (previous) => {
+              if (!previous) return;
+              return {
+                ...previous,
+                tournament: {
+                  ...previous.tournament,
+                  startedAt,
+                },
+              };
+            },
+          );
           queryClient.setQueryData(
             trpc.tournament.roundGames.queryKey({
               tournamentId,

--- a/src/components/hooks/mutation-hooks/use-tournament-start.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-start.ts
@@ -51,9 +51,11 @@ export default function useTournamentStart(
             games,
           });
         }
-        queryClient.invalidateQueries({
-          queryKey: trpc.tournament.pathKey(),
-        });
+        if (queryClient.isMutating() === 1) {
+          queryClient.invalidateQueries({
+            queryKey: trpc.tournament.pathKey(),
+          });
+        }
       },
       onError: (error) => {
         toast.error(tErrors(getAppErrorMessage(error)));

--- a/src/components/hooks/mutation-hooks/use-tournament-start.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-start.ts
@@ -51,7 +51,13 @@ export default function useTournamentStart(
             games,
           });
         }
-        if (queryClient.isMutating() === 1) {
+        if (
+          queryClient.isMutating({
+            predicate: (mutation) =>
+              mutation.options.scope?.id ===
+              `tournament-pre-start:${tournamentId}`,
+          }) === 1
+        ) {
           queryClient.invalidateQueries({
             queryKey: trpc.tournament.pathKey(),
           });

--- a/src/components/hooks/mutation-hooks/use-tournament-update-swiss-rounds-number.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-update-swiss-rounds-number.ts
@@ -49,7 +49,13 @@ export default function useSaveRoundsNumberMutation(
         }
       },
       onSettled: () => {
-        if (queryClient.isMutating() === 1) {
+        if (
+          queryClient.isMutating({
+            predicate: (mutation) =>
+              mutation.options.scope?.id ===
+              `tournament-pre-start:${tournamentId}`,
+          }) === 1
+        ) {
           queryClient.invalidateQueries({
             queryKey: trpc.tournament.info.pathKey(),
           });

--- a/src/components/hooks/mutation-hooks/use-tournament-update-swiss-rounds-number.ts
+++ b/src/components/hooks/mutation-hooks/use-tournament-update-swiss-rounds-number.ts
@@ -1,13 +1,14 @@
 'use client';
 
-import { getAppErrorMessage } from '@/lib/errors';
 import { useTRPC } from '@/components/trpc/client';
+import { getAppErrorMessage } from '@/lib/errors';
 import { DashboardMessage } from '@/types/tournament-ws-events';
 import { QueryClient, useMutation } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 
-export default function useTournamentSaveRoundsNumber(
+export default function useSaveRoundsNumberMutation(
+  tournamentId: string,
   queryClient: QueryClient,
   sendJsonMessage: (_message: DashboardMessage) => void,
 ) {
@@ -15,7 +16,8 @@ export default function useTournamentSaveRoundsNumber(
   const trpc = useTRPC();
   return useMutation(
     trpc.tournament.updateSwissRoundsNumber.mutationOptions({
-      onMutate: async ({ tournamentId, roundsNumber }) => {
+      scope: { id: `tournament-pre-start:${tournamentId}` },
+      onMutate: async ({ roundsNumber }) => {
         queryClient.cancelQueries({
           queryKey: trpc.tournament.info.queryKey({ tournamentId }),
         });

--- a/src/components/swiss-rounds-number.tsx
+++ b/src/components/swiss-rounds-number.tsx
@@ -21,7 +21,11 @@ export default function SwissRoundsNumber({
   const { data: unitCount = 0 } = useTournamentActiveUnitsCount(tournamentId);
   const queryClient = useQueryClient();
   const { sendJsonMessage, status } = useContext(DashboardContext);
-  const { mutate } = useSaveRoundsNumberMutation(queryClient, sendJsonMessage);
+  const { mutate } = useSaveRoundsNumberMutation(
+    tournamentId,
+    queryClient,
+    sendJsonMessage,
+  );
 
   const isOrganizer = status === 'organizer';
   const isFinished = !!data?.closedAt;

--- a/src/lib/handle-dashboard-socket-message.ts
+++ b/src/lib/handle-dashboard-socket-message.ts
@@ -239,6 +239,20 @@ export const handleSocketMessage = (
       });
       setRoundInView(1);
       break;
+
+    case 'reset-tournament-players':
+      queryClient.setQueryData(
+        trpc.tournament.units.queryKey({ tournamentId }),
+        [],
+      );
+      queryClient.setQueryData(
+        trpc.tournament.roundGames.queryKey({
+          tournamentId,
+          roundNumber: 1,
+        }),
+        [],
+      );
+      break;
     case 'new-round':
       queryClient.setQueryData(
         trpc.tournament.roundGames.queryKey({

--- a/src/server/mutations/tournament-units.ts
+++ b/src/server/mutations/tournament-units.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { AppError } from '@/lib/errors';
 import { validateRequest } from '@/lib/auth/lucia';
+import { AppError } from '@/lib/errors';
 import { lowerEq } from '@/lib/sql-sqlite-string';
 import { createUnit, createUnitMember } from '@/lib/tournament-dashboard';
 import { baselineUnitSort } from '@/lib/tournament-results';
@@ -12,6 +12,7 @@ import {
   games,
   players_to_units,
   tournament_units,
+  tournaments,
 } from '@/server/db/schema/tournaments';
 import { getRawTournamentUnits } from '@/server/queries/get-tournament-units';
 import { getTournamentById } from '@/server/queries/tournament-helpers';
@@ -19,8 +20,8 @@ import type { GameResult } from '@/server/zod/enums';
 import type {
   AddDoublesUnitModel,
   EditDoublesUnitModel,
-  UnitModel,
   ReorderTournamentUnitsInputModel,
+  UnitModel,
 } from '@/server/zod/tournaments';
 import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm';
 import { applyGameResult } from './tournament-games';
@@ -351,8 +352,15 @@ export async function resetTournamentUnits({
 }: {
   tournamentId: string;
 }) {
+  const tournament = await db
+    .select({ startedAt: tournaments.startedAt })
+    .from(tournaments)
+    .where(eq(tournaments.id, tournamentId))
+    .get();
+  if (!tournament) throw new AppError('TOURNAMENT_NOT_FOUND');
+  if (!!tournament.startedAt) throw new AppError('TOURNAMENT_ALREADY_STARTED');
+
   await db.transaction(async (tx) => {
-    await tx.delete(games).where(eq(games.tournamentId, tournamentId));
     const units = await tx
       .select({ id: tournament_units.id })
       .from(tournament_units)

--- a/src/types/tournament-ws-events.d.ts
+++ b/src/types/tournament-ws-events.d.ts
@@ -19,6 +19,7 @@ type DashboardMessage =
     }
   | { event: 'start-tournament'; startedAt: Date; games: GameModel[] } // it accepts date on input but has to be converted from string to date on incomming messages
   | { event: 'reset-tournament' }
+  | { event: 'reset-tournament-players' }
   | {
       event: 'new-round';
       roundNumber: GameModel['roundNumber'];


### PR DESCRIPTION
- added shared "scope" to all pre-start tournament mutations (+ update-swiss-rounds-number and start-touranament). scope makes them all fire consecutively, we immediately see optimistic result, however mutation is paused and request is sent only after previous (in the same scope) is settled

- added preStartLock boolean which is true when startTournament is mutating. when tournament is started, no more pre-start mutations are allowed (except changing rounds number). so this preStartLock makes sure that startTournament is the last mutation in pre start queue (again, except changing rounds number)

+ several more fixes around touranment dashboard