### PR TITLE
chore(lint): scope eslint to src/ and drop dead eslintIgnore

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev:local": "OFFLINE=true bunx next dev",
     "build": "next build",
     "start": "bunx --bun next start",
-    "lint": "bunx eslint .",
+    "lint": "bunx eslint src/",
     "opt": "OPT=true bunx --bun next dev",
     "analyze": "ANALYZE=true next build",
     "format": "bunx --bun prettier . --write",
@@ -144,11 +144,6 @@
     "baseUrl": "src",
     "emptyLinesAfterImports": 1
   },
-  "eslintIgnore": [
-    "src/components/ui/**/*.ts",
-    "src/components/ui/**/*.tsx",
-    "src/types/**/*.ts"
-  ],
   "trustedDependencies": [
     "@tailwindcss/oxide",
     "@vercel/speed-insights",


### PR DESCRIPTION
## Problem

`bun run lint` (and therefore `bun run check`) runs `eslint .`, which walks the whole tree. When linked working trees exist locally under `.claude/worktrees/` (parallel branches), their sources get linted too — measured locally: ~1,900 extra lintable files (~5× runtime), and one worktree's WIP contributed 3 hard errors, so `bun run check` exits 1 on an otherwise clean branch.

## Change

- `"lint": "bunx eslint ."` → `"bunx eslint src/"` — the directory holding all application code.
- Drop `package.json#eslintIgnore` — a legacy ESLint v8 field that flat config (`eslint.config.mjs`) ignores entirely; dead since the v9 migration.

## Tradeoff, stated honestly

Root-level config files (`next.config.mjs`, postcss/tailwind/commitlint configs, `eslint.config.mjs`) leave lint coverage — and they were never type-checked either (tsconfig includes only `src/**`). They all lint clean today, and each fails loudly elsewhere when broken (`next build`, the config's own load, the commit-msg hook). The alternative that keeps full-tree coverage is `globalIgnores(['.claude/**'])` in `eslint.config.mjs`; scoping the script was chosen for parity between local runs and CI, whose clean checkouts never contain the worktrees. Happy to switch mechanism if preferred.

## Verification

- `bunx eslint src/` — clean (exit 0)
- `bunx tsc --noEmit` — clean; `bun test` — 132 pass / 3 skip / 0 fail on this base (v1.11.0)

## Refs

- ESLint CLI, positional file arguments: https://eslint.org/docs/latest/use/command-line-interface
- ESLint flat-config migration (ignore mechanism changed): https://eslint.org/docs/latest/use/configure/migration-guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)